### PR TITLE
Fixed bug with interfaces' names

### DIFF
--- a/core/modules/interface_manager.py
+++ b/core/modules/interface_manager.py
@@ -1,7 +1,7 @@
 import os
 from time import sleep
 
-import namegenerator
+from coolname import generate_slug
 
 from collections import OrderedDict
 from random import randint
@@ -45,7 +45,7 @@ class InterfaceManager:
 
     def generate_interface(self) -> Interface:
         uuid = gen_uuid().hex
-        name = namegenerator.gen()
+        name = generate_slug(2)[:Interface.MAX_NAME_LENGTH]
         description = ""
         mask = f"/{randint(8, 30)}"
         ipv4_address = self.faker.ipv4_private() + mask

--- a/core/wireguard.py
+++ b/core/wireguard.py
@@ -12,7 +12,7 @@ class Interface(YamlAble):
     MAX_PORT_NUMBER = 65535
 
     MIN_NAME_LENGTH = 2
-    MAX_NAME_LENGTH = 32
+    MAX_NAME_LENGTH = 15
     REGEX_NAME = f"^[a-z][a-z\-_0-9]{{{MIN_NAME_LENGTH-1},{MAX_NAME_LENGTH-1}}}$"
     REGEX_IPV4_PARTIAL = "([1-9]|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])){3}"
     REGEX_IPV4 = f"^{REGEX_IPV4_PARTIAL}$"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask~=1.1.2
 PyYAML~=5.3.1
 yamlable~=1.0.3
-namegenerator~=1.0.6
 Faker~=5.8.0
 schedule~=1.0.0
+coolname~=1.1.0

--- a/web/static/js/modules/wireguard-iface.mjs
+++ b/web/static/js/modules/wireguard-iface.mjs
@@ -136,8 +136,12 @@ refreshKeysBtn.click(function (e) {
     sendPost(url, "Keys updated!");
 });
 
-const addIfaceBtn = $("#addBtn");
 const resetIfaceBtn = $("#resetBtn");
+resetIfaceBtn.click(function (e) {
+    location.reload();
+});
+
+const addIfaceBtn = $("#addBtn");
 addIfaceBtn.click(function (e) {
     addIfaceBtn.attr("disabled", true);
     resetIfaceBtn.attr("disabled", true);


### PR DESCRIPTION
+ Change name generator for wireguard interfaces and ensure max length is 15 characteres.
+ Fixed bug with reload button when adding interfaces.